### PR TITLE
Update the Creately Embed SDK Readme

### DIFF
--- a/packages/embed-sdk/readme.md
+++ b/packages/embed-sdk/readme.md
@@ -1,58 +1,113 @@
+# Creately Embed SDK
 
-# Embed-sdk
+This is a javascript module which can be used to embed Creately documents in your website. Once embedded, if the parent URL is authorized, it is also possible to interact with the document. This module can be used with most javascript bundlers including webpack.
 
-This is an npm module that can be used to interact with the Creately Editor when it is embedded in an application.
+## Getting Started
 
-## Installation and Usage
-### ES6 via npm
+Install the the `@creately/embed-sdk` module. For Typescript users, typings are included with the module.
 
-    npm install @creately/embed-sdk
+```typescript
+import { DocumentEmbed } from '@creately/embed-sdk';
 
-## Getting Start
+// Create a new instance with the document id
+const embed = new DocumentEmbed('qwertyasdfg', 'edit');
+```
 
-first import the package like this.
+The first parameter is the document id, the second parameter can be either `view` of `edit`. Once created, you can do several things.
 
-    import  { CreatelyEmbed }  from  '@creately/embed-sdk';
+**1) Show the embed iframe**
 
+Get the Embed iframe element using the `getIframe()` method.
 
-Then you have to configure the Embed API
+```typescript
+const iframe = embed.getElement();
+document.body.appendChild(iframe);
+```
 
-    const embed = new CreatelyEmbed({
-        'iframeParentId': 'MY_IFRAME_PARENT_ID',
-        'token': 'AUTH_TOKEN',
-        'docId': 'DOCUMENT_ID',
-        'docMode': 'edit',
-    });
-This will create iframe in the specific div that you mention.
+### Authentication
 
-You should subscribe to earlier created CreatelyEmbed object and you should pass the event that you wanted to subscribe to. You can use any Rxjs functions since this build base on Rxjs.
+The document owner can authorize websites to interact with the document. When authorized, the embed API enables a number of additional features.
 
-       embed.on('document:data:subscribe').pipe(
-        tap(docData => console.log('Document Data',docData)))
-        .subscribe();
+**2) Get document data as SVG**
 
+Get document data in SVG format (string).
 
-### You can use these events to fetch data from api,
+```typescript
+const svg = await embed.getDocumentSVG();
+console.log(svg);
+```
 
-* Subscribe to the shape touch
-    ```shape:touch:subscribe```
-* Subscribe to selection changes
-```shape:select:subscribe```
-* Subscribe to diagram data changes
-```document:data:subscribe```
-* Event type to modify document
-```document:modify```
-* Event type to set user token
-```user:setToken```
+**3) Get document data as PNG**
 
-If you required to modify the document content.you can use ```modify``` function.you can use the JSON object that you receiving from subscribing to ```document:data:subscribe``` event and update the object properties send it using below function.
+Get document data in PNG format (base64 encoded string).
 
- This code example for modifying the document,
+```typescript
+const base64 = await embed.getDocumentPNG();
+const dataUrl = `data:image/png;base64,${base64}`;
+```
 
-    embed.modify({
-        document.name = 'AAA';
-        document.shapes.aaaaaaa.x = 100;
-    }).pipe(tap(response => console.log('response',response)))
-      .subscribe();;
+**4) Read raw document data**
 
+Get document data as it is used inside Creately.
+
+```typescript
+const data = await embed.getDocumentData();
+```
+
+### Listen to Events
+
+The embed instance is a nodejs style event emitter with `addListener` and `removeListener` methods. It emits following event types.
+
+**5) subscribe to document data**
+
+Read raw document data when the document gets updated.
+
+```typescript
+embed.addListener('document:data', data => {
+  console.log('Document Name:', data.name);
+  console.log('Document Description:', data.description);
+  console.log('Document Shapes:');
+  for (const id of Object.keys(data.shapes)) {
+    const shape = data.shapes[id];
+    console.log(id, shape.x, shape.y)
+  }
+});
+```
+
+**6) subscribe to shape selection**
+
+Listen to changes to the current shape selection.
+
+```typescript
+embed.addListener('document:select', data => {
+  console.log('Selection (shape ids):', data.join(', '));
+});
+```
+
+**7) subscribe to shape click/touch**
+
+Listen to touch events on the shape.
+
+```typescript
+embed.addListener('document:touch', data => {
+  console.log('Touch (shapeId):', data);
+});
+```
+
+### Modify the Document
+
+It is also possible to make changes to the document.
+
+**8) Using the applyChange method**
+
+The `applyChange` method can be used to make changes to the document. The callback function will recieve a proxy document object which will record all changes applied to it. Using async code inside the callback function is not supported.
+
+> **warning:** applying an invalid change can partially or fully corrupt the document data
+
+```typescript
+embed.applyChange(proxy => {
+  console.log('Document Name:', proxy.name);
+  proxy.name = 'Updated document name';
+});
+```
 


### PR DESCRIPTION
Everything mentioned in this document is not implemented. Let's do some **"Readme Driven Development"**. Another requirement is to keep the module light and the dependencies minimal. Therefore, only use the following modules.

- @creately/mungo
- @creately/sakota

Let's discuss any changes in this pull request and finalize the public API.