### PR TITLE
Added proper path check to icon

### DIFF
--- a/packages/image-to-png/package-lock.json
+++ b/packages/image-to-png/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/image-to-png",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/image-to-png/package.json
+++ b/packages/image-to-png/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/image-to-png",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "This will convert Interlace PNG, SVG, GIF, ICON, BMP format to PNG image.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/image-to-png/package.json
+++ b/packages/image-to-png/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/image-to-png",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "This will convert Interlace PNG, SVG, GIF, ICON, BMP format to PNG image.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/image-to-png/src/index.ts
+++ b/packages/image-to-png/src/index.ts
@@ -30,10 +30,7 @@ export class ImageToPng {
         convertedImage = await this.convertSVGtoPNG(image);
       } else if (image.includes('/bmp')) {
         convertedImage = await this.convertBMPtoPNG(image);
-      } else if (image.includes('icon')) {
-        // NOTE: Checking for includes above.
-        // Because different file types available in icon.
-        // Example: image/vnd.microsoft.icon, image/x-icon
+      } else if (image.startsWith("/vnd.microsoft.icon") || image.startsWith("/x-icon")) {
         convertedImage = await this.convertICOtoPNG(image);
       }
 

--- a/packages/image-to-png/src/index.ts
+++ b/packages/image-to-png/src/index.ts
@@ -30,7 +30,7 @@ export class ImageToPng {
         convertedImage = await this.convertSVGtoPNG(image);
       } else if (image.includes('/bmp')) {
         convertedImage = await this.convertBMPtoPNG(image);
-      } else if (image.startsWith('/vnd.microsoft.icon') || image.startsWith('/x-icon')) {
+      } else if (image.includes('/vnd.microsoft.icon') || image.includes('/x-icon')) {
         convertedImage = await this.convertICOtoPNG(image);
       }
 

--- a/packages/image-to-png/src/index.ts
+++ b/packages/image-to-png/src/index.ts
@@ -30,7 +30,7 @@ export class ImageToPng {
         convertedImage = await this.convertSVGtoPNG(image);
       } else if (image.includes('/bmp')) {
         convertedImage = await this.convertBMPtoPNG(image);
-      } else if (image.startsWith("/vnd.microsoft.icon") || image.startsWith("/x-icon")) {
+      } else if (image.startsWith('/vnd.microsoft.icon') || image.startsWith('/x-icon')) {
         convertedImage = await this.convertICOtoPNG(image);
       }
 


### PR DESCRIPTION
[Favro Card](https://favro.com/organization/c9668dc39f1bd49fed254201/6a932da5a9e16600f2a20ca3?card=Cre-9738)

Issue where the images in base64 has `icon` keyword and the `if` condition try to convert the JPEG to ICON. Now added the exact path to check for icons.